### PR TITLE
Tighten data layer fallback scans and supervisor cleanup

### DIFF
--- a/scripts/collector_supervisor.py
+++ b/scripts/collector_supervisor.py
@@ -201,6 +201,28 @@ class ManagedProcess:
         recent = [t for t in self.restart_times if now - t <= FAST_RESTART_WINDOW_SEC]
         return len(recent) >= FAST_RESTART_MAX
 
+    def cleanup_pid_state(self) -> None:
+        if self.proc and self.proc.pid:
+            _clear_pid_state_if_matches(cwd=self.cwd, module=self.module, pid=int(self.proc.pid))
+
+    def stop(self, timeout_sec: float = 5.0) -> None:
+        if not self.proc:
+            return
+        if self.proc.poll() is not None:
+            self.cleanup_pid_state()
+            return
+        try:
+            self.proc.terminate()
+            self.proc.wait(timeout=max(0.1, float(timeout_sec)))
+        except Exception:
+            try:
+                self.proc.kill()
+                self.proc.wait(timeout=2.0)
+            except Exception:
+                pass
+        finally:
+            self.cleanup_pid_state()
+
 
 # ---------------------------------------------------------------------------
 # Main loop
@@ -232,30 +254,38 @@ async def run(cwd: Path) -> None:
     pids = " | ".join(f"{mp.name}={mp.proc.pid}" for mp in procs)
     await _send_telegram(f"[SUPERVISOR] Collector supervisor started\n{pids}")
 
-    while True:
-        await asyncio.sleep(CHECK_INTERVAL_SEC)
+    try:
+        while True:
+            await asyncio.sleep(CHECK_INTERVAL_SEC)
+            for mp in procs:
+                if not mp.is_alive():
+                    code = mp.exit_code()
+                    mp.cleanup_pid_state()
+                    log.warning(f"[{mp.name}] DIED exit_code={code} total_restarts={mp.restart_count}")
+
+                    if mp.is_crash_looping():
+                        msg = (
+                            f"[SUPERVISOR] {mp.name} crash-loop detected "
+                            f"({FAST_RESTART_MAX}+ deaths in {FAST_RESTART_WINDOW_SEC}s). "
+                            f"Backing off {BACKOFF_DELAY_SEC}s."
+                        )
+                        log.error(msg)
+                        await _send_telegram(msg)
+                        await asyncio.sleep(BACKOFF_DELAY_SEC)
+                    else:
+                        msg = f"[SUPERVISOR] {mp.name} died (exit={code}). Restarting in {RESTART_DELAY_SEC}s..."
+                        log.warning(msg)
+                        await _send_telegram(msg)
+                        await asyncio.sleep(RESTART_DELAY_SEC)
+
+                    mp.start()
+                    await _send_telegram(f"[SUPERVISOR] {mp.name} restarted (restart #{mp.restart_count})")
+    finally:
         for mp in procs:
-            if not mp.is_alive():
-                code = mp.exit_code()
-                log.warning(f"[{mp.name}] DIED exit_code={code} total_restarts={mp.restart_count}")
-
-                if mp.is_crash_looping():
-                    msg = (
-                        f"[SUPERVISOR] {mp.name} crash-loop detected "
-                        f"({FAST_RESTART_MAX}+ deaths in {FAST_RESTART_WINDOW_SEC}s). "
-                        f"Backing off {BACKOFF_DELAY_SEC}s."
-                    )
-                    log.error(msg)
-                    await _send_telegram(msg)
-                    await asyncio.sleep(BACKOFF_DELAY_SEC)
-                else:
-                    msg = f"[SUPERVISOR] {mp.name} died (exit={code}). Restarting in {RESTART_DELAY_SEC}s..."
-                    log.warning(msg)
-                    await _send_telegram(msg)
-                    await asyncio.sleep(RESTART_DELAY_SEC)
-
-                mp.start()
-                await _send_telegram(f"[SUPERVISOR] {mp.name} restarted (restart #{mp.restart_count})")
+            try:
+                mp.stop()
+            except Exception:
+                pass
 
 
 def main() -> None:
@@ -270,12 +300,6 @@ def main() -> None:
         asyncio.run(run(cwd))
     except KeyboardInterrupt:
         print("Collector supervisor stopped.")
-    finally:
-        for cfg in PROCS:
-            try:
-                _clear_pid_state_if_matches(cwd=cwd, module=str(cfg["module"]), pid=None)
-            except Exception:
-                pass
 
 
 if __name__ == "__main__":

--- a/tests/test_collector_supervisor_cleanup.py
+++ b/tests/test_collector_supervisor_cleanup.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import shutil
+import sys
+import uuid
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts import collector_supervisor as cs
+
+
+def _mk_local_tmp() -> Path:
+    p = Path("localtests") / f"collector_supervisor_{uuid.uuid4().hex[:8]}"
+    p.mkdir(parents=True, exist_ok=True)
+    return p.resolve()
+
+
+class _FakeProc:
+    def __init__(self, pid: int):
+        self.pid = pid
+        self._alive = True
+
+    def poll(self):
+        return None if self._alive else 0
+
+    def terminate(self):
+        self._alive = False
+
+    def wait(self, timeout=None):
+        self._alive = False
+        return 0
+
+    def kill(self):
+        self._alive = False
+
+
+def test_managed_process_stop_cleans_owned_pid_state():
+    tmp_path = _mk_local_tmp()
+    log = cs._setup_logger(tmp_path / "logs" / "collector_supervisor.test.log")
+    mp = cs.ManagedProcess(cs.PROCS[0], sys.executable, tmp_path, log)
+    mp.proc = _FakeProc(43210)
+    cs._write_pid_state(
+        cwd=tmp_path,
+        module=mp.module,
+        pid=mp.proc.pid,
+        launcher="test",
+        python=sys.executable,
+        args=mp.extra_args,
+    )
+    try:
+        assert cs._pid_file(tmp_path, mp.module).exists()
+        assert cs._meta_file(tmp_path, mp.module).exists()
+        mp.stop()
+        assert not cs._pid_file(tmp_path, mp.module).exists()
+        assert not cs._meta_file(tmp_path, mp.module).exists()
+    finally:
+        shutil.rmtree(tmp_path, ignore_errors=True)

--- a/tests/test_verify_data_layer_status.py
+++ b/tests/test_verify_data_layer_status.py
@@ -79,3 +79,46 @@ def test_verify_stopped_when_no_process_and_no_progress(monkeypatch):
         assert details["overall_status"] == "stopped"
     finally:
         shutil.rmtree(tmp_path, ignore_errors=True)
+
+
+def test_verify_uses_pid_meta_fallback_when_process_scan_fails(monkeypatch):
+    tmp_path = _mk_local_tmp()
+    data_dir = tmp_path / "data"
+    logs_dir = tmp_path / "logs"
+    pids_dir = logs_dir / "pids"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    pids_dir.mkdir(parents=True, exist_ok=True)
+
+    db = data_dir / "microstructure.db"
+    csv = data_dir / "event_diary.csv"
+    db.write_bytes(b"a" * 10)
+    csv.write_text("x\n", encoding="utf-8")
+    (pids_dir / "microstructure_collector.json").write_text(
+        '{"pid": 111, "cmdline_sig": "python -m data.microstructure_collector"}',
+        encoding="utf-8",
+    )
+    (pids_dir / "event_diary.json").write_text(
+        '{"pid": 222, "cmdline_sig": "python -m data.event_diary"}',
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(vdl, "_list_python_processes", lambda: ([], "process_scan_failed:access_denied"))
+
+    class _Proc:
+        def __init__(self, returncode: int):
+            self.returncode = returncode
+
+    monkeypatch.setattr(vdl.subprocess, "run", lambda *args, **kwargs: _Proc(0))
+    stats = iter([(10, 10.0), (1, 10.0), (20, 11.0), (2, 11.0)])
+    monkeypatch.setattr(vdl, "_file_stats", lambda path: next(stats))
+    monkeypatch.setattr(vdl.time, "sleep", lambda _: None)
+    monkeypatch.setattr(vdl.time, "time", lambda: 150.0)
+    try:
+        ok, details = vdl.verify(db, csv, wait_sec=1, min_db_growth_bytes=1)
+        assert ok is True
+        assert details["overall_status"] == "running"
+        assert details["process_scan"].endswith("process_scan_meta_fallback")
+        assert details["microstructure_collector_count"] == "1"
+        assert details["event_diary_count"] == "1"
+    finally:
+        shutil.rmtree(tmp_path, ignore_errors=True)

--- a/tools/data_layer_probe.py
+++ b/tools/data_layer_probe.py
@@ -192,7 +192,25 @@ def _scan_process_modules() -> Dict[str, int]:
                 if k in cl:
                     counts[k] += 1
     except Exception:
-        return counts
+        pass
+    return counts
+
+
+def _scan_process_modules_from_meta(pid_root: Path) -> Dict[str, int]:
+    counts = {"data.microstructure_collector": 0, "data.event_diary": 0}
+    mapping = {
+        "data.microstructure_collector": pid_root / "microstructure_collector.json",
+        "data.event_diary": pid_root / "event_diary.json",
+    }
+    for module, meta_path in mapping.items():
+        try:
+            payload = json.loads(meta_path.read_text(encoding="utf-8", errors="ignore"))
+            pid = int((payload or {}).get("pid") or 0)
+            cmd = str((payload or {}).get("cmdline_sig") or "")
+            if pid > 0 and module in cmd and _pid_exists(pid):
+                counts[module] += 1
+        except Exception:
+            continue
     return counts
 
 
@@ -385,6 +403,10 @@ def probe(
     details["event_diary_pid_alive"] = bool(diary_pid and _is_pid_alive_with_module(diary_pid, "data.event_diary", run_map))
 
     scan_counts = _scan_process_modules()
+    if not any(scan_counts.values()):
+        meta_counts = _scan_process_modules_from_meta(pid_root)
+        for key, value in meta_counts.items():
+            scan_counts[key] = max(int(scan_counts.get(key, 0)), int(value))
     details["scan_micro_count"] = scan_counts.get("data.microstructure_collector", 0)
     details["scan_diary_count"] = scan_counts.get("data.event_diary", 0)
 

--- a/tools/start_data_layer.ps1
+++ b/tools/start_data_layer.ps1
@@ -76,6 +76,26 @@ function Get-MatchingPids([string]$ModuleName) {
             }
         }
     } catch {
+        $metaFile = $null
+        if ($ModuleName -eq "data.microstructure_collector") {
+            $metaFile = $MicroMetaFile
+        } elseif ($ModuleName -eq "data.event_diary") {
+            $metaFile = $DiaryMetaFile
+        }
+        if ($metaFile -and (Test-Path -LiteralPath $metaFile)) {
+            try {
+                $meta = Get-Content -LiteralPath $metaFile -Raw | ConvertFrom-Json
+                $pid = [int]($meta.pid)
+                $cmd = [string]($meta.cmdline_sig)
+                if ($pid -gt 0 -and $cmd -and $cmd.Contains($ModuleName)) {
+                    $proc = Get-Process -Id $pid -ErrorAction SilentlyContinue
+                    if ($proc) {
+                        $out += $pid
+                    }
+                }
+            } catch {
+            }
+        }
     }
     return $out
 }

--- a/tools/verify_data_layer.py
+++ b/tools/verify_data_layer.py
@@ -59,6 +59,32 @@ def _list_python_processes() -> Tuple[List[Dict[str, Any]], Optional[str]]:
         return [], f"process_scan_failed:{exc}"
 
 
+def _list_python_processes_from_meta(pid_root: Path) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    mapping = [
+        pid_root / "microstructure_collector.json",
+        pid_root / "event_diary.json",
+    ]
+    for meta_path in mapping:
+        try:
+            payload = json.loads(meta_path.read_text(encoding="utf-8", errors="ignore"))
+            pid = int((payload or {}).get("pid") or 0)
+            cmd = str((payload or {}).get("cmdline_sig") or "")
+            if pid <= 0 or not cmd:
+                continue
+            proc = subprocess.run(
+                ["powershell", "-NoProfile", "-Command", f"Get-Process -Id {pid} | Out-Null"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if proc.returncode == 0:
+                rows.append({"ProcessId": pid, "CommandLine": cmd})
+        except Exception:
+            continue
+    return rows
+
+
 def _find_by_substring(rows: List[Dict[str, Any]], needle: str) -> List[Dict[str, Any]]:
     out: List[Dict[str, Any]] = []
     for r in rows:
@@ -83,6 +109,11 @@ def verify(
     fresh_window_sec = max(60, int(wait_sec) * 30)
 
     procs, scan_error = _list_python_processes()
+    if not procs:
+        meta_rows = _list_python_processes_from_meta(db_path.parent.parent / "logs" / "pids")
+        if meta_rows:
+            procs = meta_rows
+            scan_error = (f"{scan_error};" if scan_error else "") + "process_scan_meta_fallback"
     micro = _find_by_substring(procs, "data.microstructure_collector")
     diary = _find_by_substring(procs, "data.event_diary")
     details["microstructure_collector_count"] = str(len(micro))


### PR DESCRIPTION
## Summary

This PR tightens the last weak spots in data-layer liveness handling:

1. make collector_supervisor clean up owned PID/meta state correctly
2. improve process-scan fallback when Get-CimInstance Win32_Process is unavailable or access is denied

## What changed

### Supervisor cleanup
- add explicit stop/cleanup handling to scripts/collector_supervisor.py
- remove the old no-op pid=None cleanup path
- clear owned PID/meta files when a managed child exits or the supervisor shuts down

### Fallback process detection
- add PID-meta fallback scanning in 	ools/data_layer_probe.py
- add the same meta-based fallback in 	ools/verify_data_layer.py
- improve 	ools/start_data_layer.ps1 so existing-process discovery can fall back to PID/meta state when CIM scanning fails

## Why this matters

We already fixed stale PID classification, but one gap remained:
- stale or missing process scans could still degrade too aggressively on machines where CIM process access is restricted

This PR makes status checks more robust without restarting or changing the current collector/event-diary runtime topology.

## Validation

Passed targeted tests:
- 	ests/test_data_layer_probe_helpers.py
- 	ests/test_probe_require_diary_flag.py
- 	ests/test_start_data_layer_duplicate_guard.py
- 	ests/test_data_layer_pid_states.py
- 	ests/test_verify_data_layer_status.py
- 	ests/test_collector_supervisor_cleanup.py

Result:
- 21 passed

## Notes

- no collector or event-diary restart was required for this change
- this is a follow-up cleanup on top of the earlier stale-PID hardening work
